### PR TITLE
Add-password-to-data-view-window

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,56 +3,7 @@
 
 <head>
   <title>Guestbook</title>
-  <style>
-    body {
-      font-family: "Poppins", sans-serif;
-      background-color: #00447c;
-      color: white;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100vh;
-      margin: 0;
-      transition: background-color 0.3s ease;
-    }
-
-    h1 {
-      margin-bottom: 20px;
-    }
-
-    #entry-data {
-      text-align: center;
-    }
-
-    .entry-row {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      gap: 20px;
-      /* Spacing between entry fields */
-    }
-
-    .entry-field {
-      width: 200px;
-      text-align: left;
-    }
-
-    #countdown {
-      font-size: 1.2rem;
-      margin-top: 10px;
-    }
-
-    #hid-selector-parent {
-      display: none;
-    }
-
-    .error {
-      color: red;
-      font-weight: bold;
-    }
-  </style>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" type="text/css" href="styles.css">
 </head>
 
 <body>

--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ const appIcon = nativeImage.createFromPath(
 
 function promptForPassword(title, message) {
 	return new Promise((resolve, _reject) => {
+		const basePath = `file:///${__dirname.replace(/\\/g, '/')}/`;
 		const promptWindow = new BrowserWindow({
 			width: 300,
 			height: 250,
@@ -37,53 +38,21 @@ function promptForPassword(title, message) {
 			webPreferences: {
 				nodeIntegration: true,
 				contextIsolation: false,
+				webSecurity: false
 			},
 		});
 		const htmlContent = `
 			<!DOCTYPE html>
 			<html>
 			<head>
+				<base href="${basePath}">
 				<title>${title}</title>
-				<style>
-					body {
-						font-family: "Poppins", sans-serif;
-						background-color: #00447c;
-						color: white;
-						display: flex;
-						flex-direction: column;
-						align-items: center;
-						justify-content: center;
-						height: 100vh;
-						margin: 0;
-					}
-					h3 {
-						margin-bottom: 20px;
-					}
-					input {
-						width: 80%;
-						padding: 10px;
-						margin-bottom: 20px;
-						border: none;
-						border-radius: 5px;
-					}
-					button {
-						padding: 10px 20px;
-						margin: 5px;
-						border: none;
-						border-radius: 5px;
-						background-color: #007bff;
-						color: white;
-						cursor: pointer;
-					}
-					button:hover {
-						background-color: #0056b3;
-					}
-				</style>
+				<link rel="stylesheet" type="text/css" href="styles.css">
 			</head>
 			<body>
-				<h3>${message}</h3>
+				<p class="prompt-message">${message}</p>
 				<input id="pwd" type="password" autofocus />
-				<div>
+				<div class="button-container">
 					<button id="submit">Submit</button>
 					<button id="cancel">Cancel</button>
 				</div>
@@ -95,6 +64,16 @@ function promptForPassword(title, message) {
 					});
 					document.getElementById('cancel').addEventListener('click', () => {
 						ipcRenderer.send('password-prompt-response', null);
+					});
+					document.addEventListener('keydown', (event) => {
+						if (event.key === 'Enter') {
+							event.preventDefault();
+							const value = document.getElementById('pwd').value;
+							ipcRenderer.send('password-prompt-response', value);
+						} else if (event.key === 'Escape') {
+							event.preventDefault();
+							ipcRenderer.send('password-prompt-response', null);
+						}
 					});
 				</script>
 			</body>

--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ function promptForPassword(title, message) {
 	return new Promise((resolve, _reject) => {
 		const promptWindow = new BrowserWindow({
 			width: 300,
-			height: 150,
+			height: 250,
 			title: title,
 			parent: mainWindow,
 			modal: true,
@@ -40,11 +40,50 @@ function promptForPassword(title, message) {
 			},
 		});
 		const htmlContent = `
+			<!DOCTYPE html>
 			<html>
+			<head>
+				<title>${title}</title>
+				<style>
+					body {
+						font-family: "Poppins", sans-serif;
+						background-color: #00447c;
+						color: white;
+						display: flex;
+						flex-direction: column;
+						align-items: center;
+						justify-content: center;
+						height: 100vh;
+						margin: 0;
+					}
+					h3 {
+						margin-bottom: 20px;
+					}
+					input {
+						width: 80%;
+						padding: 10px;
+						margin-bottom: 20px;
+						border: none;
+						border-radius: 5px;
+					}
+					button {
+						padding: 10px 20px;
+						margin: 5px;
+						border: none;
+						border-radius: 5px;
+						background-color: #007bff;
+						color: white;
+						cursor: pointer;
+					}
+					button:hover {
+						background-color: #0056b3;
+					}
+				</style>
+			</head>
 			<body>
 				<h3>${message}</h3>
-				<input id="pwd" type="password" autofocus style="width: 100%" />
-				<div style="margin-top: 10px;">
+				<input id="pwd" type="password" autofocus />
+				<div>
 					<button id="submit">Submit</button>
 					<button id="cancel">Cancel</button>
 				</div>
@@ -309,6 +348,31 @@ ipcMain.on("flush-data", async (event) => {
 		} catch (error) {
 			console.error("Error flushing data:", error.message);
 		}
+	}
+});
+
+ipcMain.on("set-password", async () => {
+	const enteredPwd = await promptForPassword("Set/Change Password", "Enter a new password for the viewer window. Leave blank for no password:");
+	const configPath = path.join(__dirname, "wg_config.json");
+	let config = {};
+
+	if (fs.existsSync(configPath)) {
+		try {
+			const rawData = fs.readFileSync(configPath);
+			config = JSON.parse(rawData);
+		} catch (err) {
+			console.error("Error reading wg_config.json:", err.message);
+		}
+	}
+
+	config.password = enteredPwd || "";
+	viewerPassword = config.password;
+
+	try {
+		fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+		console.log("wg_config.json updated with new password");
+	} catch (err) {
+		console.error("Error writing wg_config.json:", err.message);
 	}
 });
 

--- a/main.js
+++ b/main.js
@@ -68,7 +68,27 @@ function promptForPassword(title, message) {
 			<button id="submit">Submit</button>
 			<button id="cancel">Cancel</button>
 		</div>
-		<script src="promptRenderer.js"></script>
+		<script>
+			const responseChannel = "${channelId}";
+			const { ipcRenderer } = require('electron');
+			document.getElementById('submit').addEventListener('click', () => {
+				const value = document.getElementById('pwd').value;
+				ipcRenderer.send(responseChannel, value);
+			});
+			document.getElementById('cancel').addEventListener('click', () => {
+				ipcRenderer.send(responseChannel, null);
+			});
+			document.addEventListener('keydown', (event) => {
+				if (event.key === 'Enter') {
+					event.preventDefault();
+					const value = document.getElementById('pwd').value;
+					ipcRenderer.send(responseChannel, value);
+				} else if (event.key === 'Escape') {
+					event.preventDefault();
+					ipcRenderer.send(responseChannel, null);
+				}
+			});
+		</script>
 	</body>
 </html>`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wolfpack-guestbook",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "guest attendance tracking application",
   "main": "main.js",
   "type": "commonjs",

--- a/promptPreload.js
+++ b/promptPreload.js
@@ -1,6 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
-contextBridge.exposeInMainWorld('electronAPI', {
+contextBridge.exposeInMainWorld('Electron', {
   sendResponse: (channel, value) => {
     ipcRenderer.send(channel, value);
   }

--- a/promptPreload.js
+++ b/promptPreload.js
@@ -1,0 +1,7 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  sendResponse: (channel, value) => {
+    ipcRenderer.send(channel, value);
+  }
+});

--- a/promptRenderer.js
+++ b/promptRenderer.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const metaTag = document.querySelector('meta[name="response-channel"]');
+  if (!metaTag) {
+    console.error('Response channel meta tag not found');
+    return;
+  }
+  const responseChannel = metaTag.getAttribute('content');
+
+  const submitBtn = document.getElementById('submit');
+  const cancelBtn = document.getElementById('cancel');
+  const pwdInput = document.getElementById('pwd');
+
+  submitBtn.addEventListener('click', () => {
+    window.electronAPI.sendResponse(responseChannel, pwdInput.value);
+  });
+
+  cancelBtn.addEventListener('click', () => {
+    window.electronAPI.sendResponse(responseChannel, null);
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      window.electronAPI.sendResponse(responseChannel, pwdInput.value);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      window.electronAPI.sendResponse(responseChannel, null);
+    }
+  });
+});

--- a/promptRenderer.js
+++ b/promptRenderer.js
@@ -11,20 +11,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const pwdInput = document.getElementById('pwd');
 
   submitBtn.addEventListener('click', () => {
-    window.electronAPI.sendResponse(responseChannel, pwdInput.value);
+    window.Electron.sendResponse(responseChannel, pwdInput.value);
   });
 
   cancelBtn.addEventListener('click', () => {
-    window.electronAPI.sendResponse(responseChannel, null);
+    window.Electron.sendResponse(responseChannel, null);
   });
 
   document.addEventListener('keydown', (event) => {
     if (event.key === 'Enter') {
       event.preventDefault();
-      window.electronAPI.sendResponse(responseChannel, pwdInput.value);
+      window.Electron.sendResponse(responseChannel, pwdInput.value);
     } else if (event.key === 'Escape') {
       event.preventDefault();
-      window.electronAPI.sendResponse(responseChannel, null);
+      window.Electron.sendResponse(responseChannel, null);
     }
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,90 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
+/* Common styles for Guestbook application */
+body {
+  font-family: "Poppins", sans-serif;
+  background-color: #00447c;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  margin: 0;
+  transition: background-color 0.3s ease;
+}
+
+h1 {
+  margin-bottom: 20px;
+}
+
+/* Styles for index.html */
+#entry-data {
+  text-align: center;
+}
+
+.entry-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+}
+
+.entry-field {
+  width: 200px;
+  text-align: left;
+}
+
+#countdown {
+  font-size: 1.2rem;
+  margin-top: 10px;
+}
+
+/* Styles for viewer.html */
+table {
+  width: 80%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid white;
+  padding: 8px;
+  text-align: left;
+}
+
+.button-container {
+  margin: 20px;
+}
+
+button {
+  padding: 10px 20px;
+  margin: 5px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #0056b3;
+}
+
+/* HID selector hidden by default */
+#hid-selector-parent {
+  display: none;
+}
+
+/* Error styling */
+.error {
+  color: red;
+  font-weight: bold;
+}
+
+/* Prompt styling */
+.prompt-message {
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+
+

--- a/viewer.html
+++ b/viewer.html
@@ -57,6 +57,7 @@
     <button id="reload-table">Reload Data</button>
     <button id="export-csv">Export to CSV</button>
     <button id="flush-data">Flush Data</button>
+    <button id="set-password">Set/Change Password</button>
   </div>
   <table>
     <thead>
@@ -94,6 +95,10 @@
 
     document.getElementById("flush-data").addEventListener("click", () => {
       ipcRenderer.send("flush-data");
+    });
+
+    document.getElementById("set-password").addEventListener("click", () => {
+      ipcRenderer.send("set-password");
     });
 
     ipcRenderer.send("request-entries");

--- a/viewer.html
+++ b/viewer.html
@@ -3,52 +3,7 @@
 
 <head>
   <title>Guest Entries Viewer</title>
-  <style>
-    body {
-      font-family: "Poppins", sans-serif;
-      background-color: #00447c;
-      color: white;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      height: 100vh;
-      margin: 0;
-    }
-
-    h1 {
-      margin-bottom: 20px;
-    }
-
-    table {
-      width: 80%;
-      border-collapse: collapse;
-    }
-
-    th,
-    td {
-      border: 1px solid white;
-      padding: 8px;
-      text-align: left;
-    }
-
-    .button-container {
-      margin: 20px;
-    }
-
-    button {
-      padding: 10px 20px;
-      margin: 5px;
-      background-color: #007bff;
-      color: white;
-      border: none;
-      cursor: pointer;
-    }
-
-    button:hover {
-      background-color: #0056b3;
-    }
-  </style>
+  <link rel="stylesheet" type="text/css" href="styles.css">
 </head>
 
 <body>


### PR DESCRIPTION
- Inline CSS directly in the HTML file
- Replace base href with direct file loading
- Update Electron API namespace from 'electronAPI' to 'Electron'
- Add 'alwaysOnTop' option to viewer window
- Bump version to 1.0.4

## Summary by Sourcery

This pull request introduces password protection for the data viewer window, enhancing security. It also improves code maintainability by externalizing CSS styles and updates the Electron API usage. The viewer window is now set to be always on top.

New Features:
- Adds password protection to the data viewer window, prompting for a password before displaying guest entries.
- Adds a button to the viewer window to set or change the password.

Enhancements:
- The viewer window is now set to be always on top.

Build:
- Updates the Electron API namespace from 'electronAPI' to 'Electron'.

Chores:
- Bumps the application version to 1.0.4.
- Refactors CSS to use an external stylesheet instead of inline styles.